### PR TITLE
8292863:assert(_print_inlining_stream->size() > 0) failed: missing inlining msg

### DIFF
--- a/src/hotspot/share/opto/callGenerator.cpp
+++ b/src/hotspot/share/opto/callGenerator.cpp
@@ -423,6 +423,7 @@ void LateInlineCallGenerator::do_late_inline() {
   // needs jvms for inlined state.
   if (!do_late_inline_check(jvms)) {
     map->disconnect_inputs(NULL, C);
+    C->print_inlining_update_delayed(this);
     return;
   }
 
@@ -491,8 +492,6 @@ class LateInlineMHCallGenerator : public LateInlineCallGenerator {
 bool LateInlineMHCallGenerator::do_late_inline_check(JVMState* jvms) {
 
   CallGenerator* cg = for_method_handle_inline(jvms, _caller, method(), _input_not_const);
-
-  Compile::current()->print_inlining_update_delayed(this);
 
   if (!_input_not_const) {
     _attempt++;


### PR DESCRIPTION
assert in print_inlining_update_delayed is checking for an empty inline stream buffer which is expected to be empty.

Fix is to call print_inlining_update_delayed() only when do_late_inline_check() fails in do_late_inline() which is similar to JDK17 code where this issue doesn't reproduce.